### PR TITLE
Reduce interrupt warnings

### DIFF
--- a/update_load_seg_db.py
+++ b/update_load_seg_db.py
@@ -360,11 +360,11 @@ def rdb_to_db_schema( orig_ifot_loads ):
     return load_recs
 
 
-def check_load_overlap( loads ):
+def check_load_overlap( loads, max_sep_hours=36):
     """
     Checks command load segment overlap
 
-    Logs warnings for : separation greater than 6 hours
+    Logs warnings for : separation greater than max_sep_hours hours
                         any overlap in the same SCS    
                         
     :param loads: recarray of load segments
@@ -373,12 +373,11 @@ def check_load_overlap( loads ):
 
     sep_times = ( DateTime(loads[1:]['datestart']).secs 
                   - DateTime(loads[:-1]['datestop']).secs )
-    max_sep_hours = 12
     max_sep = max_sep_hours * 60 * 60
     # check for too much sep
     if (any(sep_times > max_sep )):
         for load_idx in np.flatnonzero(sep_times > max_sep):
-            log.warn('LOAD_SEG WARN: Loads %s %s separated by more that %i hours' 
+            log.warn('LOAD_SEG WARN: Loads %s %s separated by more than %i hours' 
                          % (loads[load_idx]['load_segment'],
                             loads[load_idx+1]['load_segment'],
                             max_sep_hours ))


### PR DESCRIPTION
This PR reduces the noise of interrupt warnings like:

```
LOAD_SEG WARN: Loads CL206:1103 CL208:2305 separated by more that 12 hours 
```

by
1. increasing the threshold by which command loads must be separated before throwing a warning from 12 to 36 hours
2. only throwing a warning on overlap or separation during the job if there is an actual database update (code was throwing the warning every time the tool was run even if there were no actions)
