### PR TITLE
Create a complete sqlite version of cmd_states tables

### DIFF
--- a/NOTES.create-cmd_states.db3
+++ b/NOTES.create-cmd_states.db3
@@ -1,0 +1,4 @@
+To make the fresh sqlite3 version of relevant command states Sybase tables:
+
+$ ./make_new_tables.py --tstart=1999:001 --cmds --cmd-states  # takes a few minutes
+$ cp db_base.db3 $SKA/data/cmd_states/cmd_states.db3  # as "aca" user

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -1,9 +1,9 @@
-# Configuration file for task_schedule.pl 
+# Configuration file for task_schedule.pl
 
 subject      Update timelines and cmd_states   # subject of email
-timeout      5000			  # Default tool timeout
-heartbeat_timeout 300			  # Maximum age of heartbeat file (seconds)
-loud         0				  # Run loudly
+timeout      5000                         # Default tool timeout
+heartbeat_timeout 300                     # Maximum age of heartbeat file (seconds)
+loud         0                            # Run loudly
 
 # Data files and directories.  The *_dir vars can have $ENV{} vars which
 # get interpolated.  (Note lack of task name after TST_DATA because this is just for test).
@@ -19,7 +19,7 @@ disable_alerts 0
 # Processing errors *within* the jobs are caught with watch_cron_logs
 
 alert       aca@head.cfa.harvard.edu
-#notify	    jeanconn@head.cfa.harvard.edu
+#notify     jeanconn@head.cfa.harvard.edu
 # alert       another_person@head.cfa.harvard.edu
 
 # Define task parameters
@@ -39,10 +39,13 @@ alert       aca@head.cfa.harvard.edu
 
 <task timelines_cmd_states>
       cron       */10 * * * *
-      check_cron 15 7 * * * 
-      exec 1: parse_cmd_load_gen.pl --dbi 'sybase' --server 'sybase' --verbose 
-      exec 1: update_load_seg_db.py --dbi 'sybase' --server 'sybase' --verbose 
+      check_cron 15 7 * * *
+      exec 1: parse_cmd_load_gen.pl --dbi 'sybase' --server 'sybase' --verbose
+      exec 1: parse_cmd_load_gen.pl --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
+      exec 1: update_load_seg_db.py --dbi 'sybase' --server 'sybase' --verbose
+      exec 1: update_load_seg_db.py --dbi 'sqlite' --server '$ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
       exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sybase' --server 'sybase' --h5file $ENV{SKA_DATA}/cmd_states/cmd_states.h5
+      exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --h5file ""
       context 1
       <check>
         <error>

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -41,10 +41,10 @@ alert       aca@head.cfa.harvard.edu
       cron       */10 * * * *
       check_cron 15 7 * * *
       exec 1: parse_cmd_load_gen.pl --dbi 'sybase' --server 'sybase' --verbose
-      exec 1: parse_cmd_load_gen.pl --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
       exec 1: update_load_seg_db.py --dbi 'sybase' --server 'sybase' --verbose
-      exec 1: update_load_seg_db.py --dbi 'sqlite' --server '$ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
       exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sybase' --server 'sybase' --h5file $ENV{SKA_DATA}/cmd_states/cmd_states.h5
+      exec 1: parse_cmd_load_gen.pl --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
+      exec 1: update_load_seg_db.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
       exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --h5file ""
       context 1
       <check>


### PR DESCRIPTION
The branch is py3, but this is really just to support no-sybase operation with a single sqlite3 database that has all the relevant tables.

No Py3 compatibility code changes are made.