### PR TITLE
Fix get_replan_dir to work over year boundary

### DIFF
--- a/update_load_seg_db.py
+++ b/update_load_seg_db.py
@@ -114,11 +114,12 @@ def get_replan_dir( replan_seg, replan_year, dbh=None):
     if match_like is None:
         raise ValueError("Replan load seg %s is in unknown form, expects /C\d{3}?\d{4}/" %
                          replan_seg)
-    replan_query = ("""select dir from tl_processing
+    replan_query = ("""select * from tl_processing
                        where file like 'C%s%s%s.sum'
-                       and year = %d 
+                       and year = %d or (year = %d and sumfile_modtime > %f)
                        order by year, sumfile_modtime desc
-                       """ % (match_like.group(1), '%', match_like.group(2), replan_year ))
+                       """ % (match_like.group(1), '%', match_like.group(2),
+                              replan_year, int(replan_year) - 1, DateTime(-21).unix))
     replan = dbh.fetchone( replan_query )
     # if a replan directory *still* hasn't been found
     if replan  is None:

--- a/update_load_seg_db.py
+++ b/update_load_seg_db.py
@@ -114,6 +114,13 @@ def get_replan_dir( replan_seg, replan_year, dbh=None):
     if match_like is None:
         raise ValueError("Replan load seg %s is in unknown form, expects /C\d{3}?\d{4}/" %
                          replan_seg)
+    # This query is intended to return the entry from the table of parsed/processed command
+    # load processing summaries that corresponds to the segment referenced as the piece
+    # being replanned from the current processing summary "replan_seg".  "replan_year" is supplied
+    # as the year of the current processing summary, but, in case of replan across a year
+    # boundary, logic is added to also allow files to be considered a match if from the
+    # previous year and modified during the last 21 days.
+    # The most recent file that matches the query will be used as the reference.
     replan_query = ("""select * from tl_processing
                        where file like 'C%s%s%s.sum'
                        and year = %d or (year = %d and sumfile_modtime > %f)

--- a/update_load_seg_db.py
+++ b/update_load_seg_db.py
@@ -114,13 +114,15 @@ def get_replan_dir( replan_seg, replan_year, dbh=None):
     if match_like is None:
         raise ValueError("Replan load seg %s is in unknown form, expects /C\d{3}?\d{4}/" %
                          replan_seg)
-    # This query is intended to return the entry from the table of parsed/processed command
-    # load processing summaries that corresponds to the segment referenced as the piece
-    # being replanned from the current processing summary "replan_seg".  "replan_year" is supplied
-    # as the year of the current processing summary, but, in case of replan across a year
-    # boundary, logic is added to also allow files to be considered a match if from the
-    # previous year and modified during the last 21 days.
-    # The most recent file that matches the query will be used as the reference.
+    # get_replan_dirs is called on a text string from the command load generation processing
+    # summary that was the "replan source" and then this is trying to match up that source to
+    # a directory using the string/file name. Unfortunately, the file names are not guaranteed
+    # to be unique across calendar years, so this routine had code to limit to just the year
+    # of the replan (and that's why the files are also in a table that has year). I can't see
+    # any harm in using either the year of the replan or "last year" if the "last year" file
+    # was also created/modified within 21 days. This still is all hoping that the file names
+    # are at least unique within the year.
+    # The most recent file that matches the query will be used.
     replan_query = ("""select * from tl_processing
                        where file like 'C%s%s%s.sum'
                        and year = %d or (year = %d and sumfile_modtime > %f)


### PR DESCRIPTION
Fix get_replan_dir to work over year boundary.

It looks like get_replan_dir previously expected that it was sufficient to just check the "current" year for matching files to search for replan continuity.  This is not sufficient for a replan across the year boundary.  This change sets the routine that looks for a match to also search the previous year but requires that the reference file (the summary file used to line up the replan with an actual directory) be modified in the last 3 weeks.  