### PR TITLE
WIP: port to work on Ska3

### DIFF
--- a/fix_load_segments.py
+++ b/fix_load_segments.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
 
-import Ska.DBI
-from Chandra.Time import DateTime
-
-
 def repair(ifot_loads):
     """
     Make any known edits to a recarray of load segments.  This is called
@@ -12,78 +8,79 @@ def repair(ifot_loads):
 
     :param ifot_loads: numpy.recarray from the (Ska.Table) parsed rdb of load segments from arc/iFOT
     :rtype: numpy.recarray
-    
+
     """
 
     import numpy as np
 
     # delete a load that was never run
-    match = ((ifot_loads.load_segment == 'CL304:0504') &
-             (ifot_loads.year == 2003))
+    match = ((ifot_loads.load_segment == 'CL304:0504')
+             & (ifot_loads.year == 2003))
     if any(match):
         # slice to get the ones that don't match
-        ifot_loads = ifot_loads[match == False]
+        ifot_loads = ifot_loads[~match]
 
     # repair a couple of loads
     # 352 ended early at...
-    match = ((ifot_loads.load_segment == 'CL352:1208') &
-             (ifot_loads.year == 2008)) 
+    match = ((ifot_loads.load_segment == 'CL352:1208')
+             & (ifot_loads.year == 2008))
     if any(match):
         ifot_loads.datestop[match] = '2008:353:05:00:00.000'
         ifot_loads.fixed_by_hand[match] = 1
 
     # CL110:1404 was run, not CL110:1409
-    match = ((ifot_loads.load_segment == 'CL110:1409') &
-             (ifot_loads.year == 2003)) 
+    match = ((ifot_loads.load_segment == 'CL110:1409')
+             & (ifot_loads.year == 2003))
     if any(match):
-        rec_tuple = ( 'CL110:1404', 2003,
-                      '2003:110:14:07:09.439', '2003:112:00:00:31.542', 130, 1)
+        rec_tuple = ('CL110:1404', 2003,
+                     '2003:110:14:07:09.439', '2003:112:00:00:31.542', 130, 1)
         # ifot_list except the bad one
-        ifot_list = ifot_loads[match == False].tolist()
+        ifot_list = ifot_loads[~match].tolist()
         ifot_list.append(rec_tuple)
-	    # sort by datestart in third field
-        ifot_list.sort(lambda x,y: cmp(x[2],y[2]))
-        new_ifot = np.rec.fromrecords( ifot_list,
-                                       dtype=ifot_loads.dtype,
-                                       )
-        ifot_loads = new_ifot
+        # sort by datestart in third field
 
+        def cmp(a, b):
+            return (a > b) - (a < b)
+        ifot_list.sort(lambda x, y: cmp(x[2], y[2]))
+        new_ifot = np.rec.fromrecords(ifot_list,
+                                      dtype=ifot_loads.dtype,
+                                      )
+        ifot_loads = new_ifot
 
     # CL188:0402 is missing
     cmd_date = '2009:188:04:00:00.000'
 
     if ((ifot_loads[0].datestart <= cmd_date) and (ifot_loads[-1].datestart > cmd_date)):
-        if np.flatnonzero((ifot_loads.load_segment == 'CL188:0402') &
-                          (ifot_loads.year == 2009)):
+        if np.flatnonzero((ifot_loads.load_segment == 'CL188:0402')
+                          & (ifot_loads.year == 2009)):
             pass
         else:
-            rec_tuple = ( 'CL188:0402', 2009,
+            rec_tuple = ('CL188:0402', 2009,
                          '2009:188:04:00:00.000', '2009:188:20:57:33.571', 129, 1)
             ifot_list = ifot_loads.tolist()
             ifot_list.append(rec_tuple)
-            ifot_list.sort(lambda x,y: cmp(x[2],y[2]))
-            new_ifot = np.rec.fromrecords( ifot_list,
-                                           dtype=ifot_loads.dtype,
-                                           )
+            ifot_list.sort(lambda x, y: cmp(x[2], y[2]))
+            new_ifot = np.rec.fromrecords(ifot_list,
+                                          dtype=ifot_loads.dtype,
+                                          )
             ifot_loads = new_ifot
 
     # 2011 CL103:2002 is missing, interrupted by  the APR1311 replan
     cmd_date = '2011:103:20:40:00.000'
 
     if ((ifot_loads[0].datestart <= cmd_date) and (ifot_loads[-1].datestart > cmd_date)):
-        if np.flatnonzero((ifot_loads.load_segment == 'CL103:2002') &
-                          (ifot_loads.year == 2011)):
+        if np.flatnonzero((ifot_loads.load_segment == 'CL103:2002')
+                          & (ifot_loads.year == 2011)):
             pass
         else:
-            rec_tuple = ( 'CL103:2002', 2011,
+            rec_tuple = ('CL103:2002', 2011,
                          '2011:103:20:40:00.000', '2011:103:22:57:00.000', 129, 1)
             ifot_list = ifot_loads.tolist()
             ifot_list.append(rec_tuple)
-            ifot_list.sort(lambda x,y: cmp(x[2],y[2]))
-            new_ifot = np.rec.fromrecords( ifot_list,
-                                           dtype=ifot_loads.dtype,
-                                           )
+            ifot_list.sort(lambda x, y: cmp(x[2], y[2]))
+            new_ifot = np.rec.fromrecords(ifot_list,
+                                          dtype=ifot_loads.dtype,
+                                          )
             ifot_loads = new_ifot
-
 
     return ifot_loads

--- a/fix_tl_processing.py
+++ b/fix_tl_processing.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import Ska.DBI
-from Chandra.Time import DateTime
+
 
 def get_options():
     from optparse import OptionParser
@@ -17,26 +17,27 @@ def get_options():
     return opt, args
 
 
-def repair( dbh ):
+def repair(dbh):
     """
     Make any necessary edits to the tl_processing table.  This is called in
     update_load_seg_db.py before loads are inserted and timelines are determined.
 
     It is not expected that any edits will need to be created, but this mechanism
     is scripted into the suite to allow the possibility.
-    
+
     If, at some point, we need to manually override mapping of replan commands
     to a specific directory instead of the one determined by parse_cmd_load_gen.pl,
     we could use something like the commented-out code in this routine.
     """
     dbh.verbose = True
-    #dbh.execute("delete from tl_processing where dir = '/2008/FEB1808/oflsb/'")
-    #dbh.execute("""insert into tl_processing
-    #( year, dir, file )
-    #values 
-    #(2008, '/2008/FEB1808/oflsb/', 'C048_0802.sum')
-    #""")
+    # dbh.execute("delete from tl_processing where dir = '/2008/FEB1808/oflsb/'")
+    # dbh.execute("""insert into tl_processing
+    # ( year, dir, file )
+    # values
+    # (2008, '/2008/FEB1808/oflsb/', 'C048_0802.sum')
+    # """)
     dbh.verbose = False
+
 
 def main():
     opt, args = get_options()

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -40,12 +40,9 @@ alert       aca@head.cfa.harvard.edu
 <task timelines_cmd_states>
       cron       */10 * * * *
       check_cron 15 7 * * *
-      exec 1: parse_cmd_load_gen.pl --dbi 'sybase' --server 'sybase' --verbose
-      exec 1: update_load_seg_db.py --dbi 'sybase' --server 'sybase' --verbose
-      exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sybase' --server 'sybase' --h5file $ENV{SKA_DATA}/cmd_states/cmd_states.h5
-      exec 1: parse_cmd_load_gen.pl --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --touch_file $ENV{SKA_DATA}/timelines/sum_files_sqlite3.touch  --verbose 
-      exec 1: update_load_seg_db.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --verbose
-      exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states/cmd_states.db3 --h5file ''
+      exec 1: parse_cmd_load_gen.pl --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states3/cmd_states.db3 --touch_file $ENV{SKA_DATA}/timelines/sum_files_sqlite3.touch  --verbose
+      exec 1: update_load_seg_db.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states3/cmd_states.db3 --verbose
+      exec 6: $ENV{SKA_SHARE}/cmd_states/update_cmd_states.py --dbi 'sqlite' --server $ENV{SKA_DATA}/cmd_states3/cmd_states.db3 --h5file ''
       context 1
       <check>
         <error>

--- a/update_load_seg_db.py
+++ b/update_load_seg_db.py
@@ -7,7 +7,7 @@ import re
 import logging
 from logging.handlers import SMTPHandler
 import numpy as np
-from itertools import count, izip
+from itertools import count
 
 import Ska.Table
 from Ska.DBI import DBI
@@ -225,9 +225,9 @@ def get_ref_timelines( datestart, dbh=None, n=10):
     pre_query =  ("select * from timelines where datestart <= '%s' order by datestart desc"
                   %  datestart )
     pre_query_fetch = dbh.fetch(pre_query)
-    for cnt in xrange(0,n):
+    for cnt in range(0,n):
         try:
-            ref_timelines.append( pre_query_fetch.next() )
+            ref_timelines.append( next(pre_query_fetch) )
         except StopIteration:
             if (cnt == 0):
                 log.warn("""TIMELINES WARN: no timelines found before current insert""")
@@ -469,7 +469,7 @@ def find_load_seg_changes(wants, haves, exclude=[]):
     # haves (the usual append condition) it gets set to the index of
     # the first new entry in wants.
     i_diff = 0
-    for want_entry, have_entry in izip(wants, haves):
+    for want_entry, have_entry in zip(wants, haves):
         # does the db load match?
         if (any(have_entry[x] != want_entry[x] for x in match_cols) ):
             log.info('LOAD_SEG INFO: Mismatch on these entries:')


### PR DESCRIPTION
## Description

This is a WIP to port basic timelines functionality to work in Ska3. Some points of note:

- Support for sybase is dropped and the database DBI is hardcoded as sqlite.
- Most of the diffs are whitespace, which can be ignored in the diff settings.
NOTE: https://github.com/sot/xija/issues/114

## Testing

So far:
```
cp $SKA/data/cmd_states/cmd_states.db3 ./
cp -p $SKA/data/timelines/sum_files_sqlite3.touch ./
./parse_cmd_load_gen.pl --server ./cmd_states.db3 --touch_file ./sum_files_sqlite3.touch --verbose
./update_load_seg_db.py --server ./cmd_states.db3 --verbose
```
The first time I ran this it did a lot more processing than I expected given that the production version basically in a static situation (no loads changed/updated recently).
```
ska3-kady$ ./update_load_seg_db.py --server ./cmd_states.db3 --verbose
Connecting to sqlite server ./cmd_states.db3
LOAD_SEG DEBUG: Updating from /proj/sot/ska3/flight/data/arc/iFOT_events/load_segment/2021:299:10:31:00.000.rdb
Running: ('SELECT max(id) AS max_id FROM timelines',)
LOAD_SEG INFO: Updating Loads for range 2021:279:02:52:54.460 to 2021:305:01:39:10.961
Running: ('SELECT max(id) AS max_id FROM load_segments',)
Running: ("select * from load_segments\n                               where datestart >= '2021:279:02:52:54.460'\n                               order by datestart, load_scs",)
LOAD_SEG INFO: Mismatch on these entries:
('CL294:0801', 2021, '2021:294:08:44:14.702', '2021:296:10:41:57.000', 128, 0)
(426104749, 'CL294:0801', 2021, '2021:294:08:44:14.702', '2021:297:14:00:51.886', 128, 0)
Running: ("select * from load_segments where datestart >= '2021:305:01:39:10.961'",)
Running: ('SELECT * from timelines where load_segment_id = 426104749',)
TIMELINES DEBUG:  DELETE from cmd_fltpars
                   WHERE timeline_id = 426104880 
Running: (' DELETE from cmd_fltpars\n                   WHERE timeline_id = 426104880 ',)
TIMELINES DEBUG:  DELETE from cmd_intpars
                   WHERE timeline_id = 426104880 
Running: (' DELETE from cmd_intpars\n                   WHERE timeline_id = 426104880 ',)
TIMELINES DEBUG:  DELETE from cmds
                   WHERE timeline_id = 426104880 
Running: (' DELETE from cmds\n                   WHERE timeline_id = 426104880 ',)
TIMELINES DEBUG: DELETE FROM timelines
              WHERE id = 426104880
              AND fixed_by_hand = 0 
Running: ('DELETE FROM timelines\n              WHERE id = 426104880\n              AND fixed_by_hand = 0 ',)
...
A bunch more like that.
```
